### PR TITLE
Only load plugins on systems that support them

### DIFF
--- a/plugins.go
+++ b/plugins.go
@@ -4,9 +4,15 @@ import (
 	"os"
 	"path/filepath"
 	"plugin"
+	"runtime"
 )
 
 func loadPlugins() error {
+	switch runtime.GOOS {
+	case "darwin", "freebsd", "linux":
+	default:
+		return nil
+	}
 	configPath, err := os.UserConfigDir()
 	if err != nil {
 		return err


### PR DESCRIPTION
Previously it would show an error on startup if a plugin was present on unsupported systems.